### PR TITLE
Add Ideal Postcodes address validation module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# AddressValidation
+# Ideal Postcodes Address Validation for Magento 2
+
+This repository contains a Magento 2.4.8-p2 module that validates customer and checkout addresses using the [Ideal Postcodes Autocomplete API](https://api.ideal-postcodes.co.uk/v1/autocomplete/addresses).
+
+## Features
+
+- Validates customer address book entries when they are saved through the Magento API or storefront.
+- Verifies shipping and billing addresses submitted during checkout.
+- Allows merchants to configure the API key, enable/disable validation, restrict validation to specific countries, and control the minimum accepted match score.
+
+## Installation
+
+1. Copy the module to `app/code/Idealpostcodes/AddressValidation` within your Magento installation (this repository already uses that structure).
+2. Run Magento setup upgrades:
+
+   ```bash
+   bin/magento module:enable Idealpostcodes_AddressValidation
+   bin/magento setup:upgrade
+   bin/magento cache:flush
+   ```
+
+## Configuration
+
+1. In the Magento Admin Panel, navigate to **Stores → Configuration → Services → Ideal Postcodes → Address Validation**.
+2. Enable the module and enter your Ideal Postcodes API key.
+3. Optionally restrict validation to specific countries and/or adjust the minimum accepted match score.
+
+## How It Works
+
+- On address save and during checkout, the module builds a search query from the provided address fields and sends it to the Ideal Postcodes Autocomplete API.
+- If the API returns no valid matches, the module throws a validation error and prompts the shopper to review their address.
+- When the API is unavailable or responds with an error, the module surfaces a generic error message while logging the technical details for debugging.
+
+## Notes
+
+- The module gracefully skips validation if it is disabled or if the API key has not been configured.
+- By default, validation runs for UK addresses (`GB`). You can update the configuration to cover more countries or leave the field blank to validate globally.
+- API timeouts are kept intentionally low (5 seconds) to avoid slowing down checkout experiences.

--- a/app/code/Idealpostcodes/AddressValidation/Model/AddressDataExtractor.php
+++ b/app/code/Idealpostcodes/AddressValidation/Model/AddressDataExtractor.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace Idealpostcodes\AddressValidation\Model;
+
+use Magento\Customer\Api\Data\RegionInterface as CustomerRegionInterface;
+use Magento\Directory\Api\Data\RegionInterface;
+use Magento\Framework\Api\ExtensibleDataInterface;
+
+class AddressDataExtractor
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function extract(ExtensibleDataInterface $address): array
+    {
+        $street = [];
+        if (method_exists($address, 'getStreet')) {
+            $streetData = $address->getStreet();
+            if (is_array($streetData)) {
+                $street = $streetData;
+            } elseif ($streetData !== null) {
+                $street = [(string) $streetData];
+            }
+        }
+
+        return [
+            'street' => $street,
+            'city' => method_exists($address, 'getCity') ? (string) $address->getCity() : '',
+            'region' => $this->extractRegion($address),
+            'postcode' => method_exists($address, 'getPostcode') ? (string) $address->getPostcode() : '',
+            'country_id' => method_exists($address, 'getCountryId') ? (string) $address->getCountryId() : '',
+        ];
+    }
+
+    private function extractRegion(ExtensibleDataInterface $address): string
+    {
+        if (method_exists($address, 'getRegion')) {
+            $region = $address->getRegion();
+            if (is_string($region)) {
+                return $region;
+            }
+
+            if ($region instanceof CustomerRegionInterface || $region instanceof RegionInterface) {
+                $regionName = $region->getRegion();
+                if ($regionName) {
+                    return $regionName;
+                }
+
+                $regionCode = $region->getRegionCode();
+                if ($regionCode) {
+                    return $regionCode;
+                }
+            }
+
+            if (is_object($region) && method_exists($region, 'getRegion')) {
+                $regionName = $region->getRegion();
+                if (is_string($regionName) && $regionName !== '') {
+                    return $regionName;
+                }
+            }
+        }
+
+        return '';
+    }
+}

--- a/app/code/Idealpostcodes/AddressValidation/Model/Api/AddressValidator.php
+++ b/app/code/Idealpostcodes/AddressValidation/Model/Api/AddressValidator.php
@@ -1,0 +1,178 @@
+<?php
+declare(strict_types=1);
+
+namespace Idealpostcodes\AddressValidation\Model\Api;
+
+use Idealpostcodes\AddressValidation\Model\Config;
+use Magento\Framework\HTTP\Client\Curl;
+use Magento\Framework\Serialize\Serializer\Json;
+use Psr\Log\LoggerInterface;
+use function __;
+
+class AddressValidator
+{
+    private const ENDPOINT = 'https://api.ideal-postcodes.co.uk/v1/autocomplete/addresses';
+
+    public function __construct(
+        private readonly Curl $curl,
+        private readonly Json $serializer,
+        private readonly Config $config,
+        private readonly LoggerInterface $logger
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $addressData
+     */
+    public function validate(array $addressData, ?int $storeId = null): ValidationResult
+    {
+        if (!$this->config->isEnabled($storeId)) {
+            return new ValidationResult(true);
+        }
+
+        $apiKey = $this->config->getApiKey($storeId);
+        if ($apiKey === '') {
+            $this->logger->warning('Ideal Postcodes validation skipped: API key not configured.');
+            return new ValidationResult(true);
+        }
+
+        if (!$this->isCountryAllowed($addressData, $storeId)) {
+            return new ValidationResult(true);
+        }
+
+        $query = $this->buildQuery($addressData);
+        if ($query === '') {
+            return new ValidationResult(true);
+        }
+
+        $params = [
+            'api_key' => $apiKey,
+            'query' => $query,
+            'limit' => 1,
+        ];
+
+        if (!empty($addressData['postcode'])) {
+            $params['filters[postcode]'] = strtoupper(trim((string) $addressData['postcode']));
+        }
+
+        try {
+            $this->curl->reset();
+            $this->curl->addHeader('Accept', 'application/json');
+            $this->curl->setTimeout(5);
+            $this->curl->get(self::ENDPOINT, $params);
+        } catch (\Throwable $exception) {
+            $this->logger->error('Ideal Postcodes validation failed', ['exception' => $exception]);
+            return new ValidationResult(false, __('We could not validate your address at this time. Please try again.'));
+        }
+
+        $status = $this->curl->getStatus();
+        $body = $this->curl->getBody();
+
+        if ($status !== 200) {
+            $this->logger->error('Ideal Postcodes API returned non-success status', ['status' => $status, 'response' => $body]);
+            return new ValidationResult(false, __('We could not validate your address. Please review the details and try again.'));
+        }
+
+        try {
+            $decoded = $this->serializer->unserialize($body);
+        } catch (\InvalidArgumentException $exception) {
+            $this->logger->error('Ideal Postcodes API response could not be decoded', ['exception' => $exception, 'response' => $body]);
+            return new ValidationResult(false, __('We could not validate your address. Please verify it and try again.'));
+        }
+
+        if (!is_array($decoded) || empty($decoded['suggestions']) || !is_array($decoded['suggestions'])) {
+            return new ValidationResult(false, __('We could not find a matching address. Please check the details.'));
+        }
+
+        $minimumScore = $this->config->getMinimumScore($storeId);
+        $postcode = isset($addressData['postcode']) ? strtoupper(trim((string) $addressData['postcode'])) : '';
+        foreach ($decoded['suggestions'] as $suggestion) {
+            if (!is_array($suggestion)) {
+                continue;
+            }
+            $score = 1.0;
+            if (isset($suggestion['score'])) {
+                $score = (float) $suggestion['score'];
+            } elseif (isset($suggestion['confidence'])) {
+                $score = (float) $suggestion['confidence'];
+            }
+            if ($score < $minimumScore) {
+                continue;
+            }
+            if ($postcode !== '') {
+                $suggestionPostcode = '';
+                if (isset($suggestion['postcode'])) {
+                    $suggestionPostcode = (string) $suggestion['postcode'];
+                } elseif (isset($suggestion['postcode_out'], $suggestion['postcode_in'])) {
+                    $suggestionPostcode = sprintf('%s %s', $suggestion['postcode_out'], $suggestion['postcode_in']);
+                } elseif (isset($suggestion['postcode_out'])) {
+                    $suggestionPostcode = (string) $suggestion['postcode_out'];
+                }
+
+                if ($suggestionPostcode !== '' && strtoupper(trim($suggestionPostcode)) !== $postcode) {
+                    continue;
+                }
+            }
+
+            return new ValidationResult(true, null, ['suggestion' => $suggestion]);
+        }
+
+        return new ValidationResult(false, __('We could not validate your address. Please double-check the information.'));
+    }
+
+    /**
+     * @param array<string, mixed> $addressData
+     */
+    private function buildQuery(array $addressData): string
+    {
+        $parts = [];
+        if (!empty($addressData['street'])) {
+            if (is_array($addressData['street'])) {
+                foreach ($addressData['street'] as $line) {
+                    $line = trim((string) $line);
+                    if ($line !== '') {
+                        $parts[] = $line;
+                    }
+                }
+            } else {
+                $street = trim((string) $addressData['street']);
+                if ($street !== '') {
+                    $parts[] = $street;
+                }
+            }
+        }
+
+        foreach (['city', 'region', 'postcode'] as $field) {
+            if (!empty($addressData[$field])) {
+                $value = trim((string) $addressData[$field]);
+                if ($value !== '') {
+                    $parts[] = $value;
+                }
+            }
+        }
+
+        if (!empty($addressData['country_id'])) {
+            $parts[] = (string) $addressData['country_id'];
+        }
+
+        $parts = array_unique($parts);
+
+        return implode(', ', $parts);
+    }
+
+    /**
+     * @param array<string, mixed> $addressData
+     */
+    private function isCountryAllowed(array $addressData, ?int $storeId = null): bool
+    {
+        $allowedCountries = $this->config->getAllowedCountries($storeId);
+        if ($allowedCountries === []) {
+            return true;
+        }
+
+        $countryId = isset($addressData['country_id']) ? strtoupper((string) $addressData['country_id']) : '';
+        $allowedCountries = array_map('strtoupper', $allowedCountries);
+
+        return $countryId === '' || in_array($countryId, $allowedCountries, true);
+    }
+}

--- a/app/code/Idealpostcodes/AddressValidation/Model/Api/ValidationResult.php
+++ b/app/code/Idealpostcodes/AddressValidation/Model/Api/ValidationResult.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Idealpostcodes\AddressValidation\Model\Api;
+
+use Magento\Framework\Phrase;
+
+class ValidationResult
+{
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function __construct(
+        private readonly bool $valid,
+        private readonly Phrase|string|null $message = null,
+        private readonly array $payload = []
+    ) {
+    }
+
+    public function isValid(): bool
+    {
+        return $this->valid;
+    }
+
+    public function getMessage(): Phrase|string|null
+    {
+        return $this->message;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getPayload(): array
+    {
+        return $this->payload;
+    }
+}

--- a/app/code/Idealpostcodes/AddressValidation/Model/Config.php
+++ b/app/code/Idealpostcodes/AddressValidation/Model/Config.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Idealpostcodes\AddressValidation\Model;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Store\Model\ScopeInterface;
+
+class Config
+{
+    private const XML_PATH_ENABLED = 'idealpostcodes/general/enabled';
+    private const XML_PATH_API_KEY = 'idealpostcodes/general/api_key';
+    private const XML_PATH_COUNTRY_FILTER = 'idealpostcodes/general/country_filter';
+    private const XML_PATH_MINIMUM_SCORE = 'idealpostcodes/general/minimum_score';
+
+    public function __construct(
+        private readonly ScopeConfigInterface $scopeConfig,
+        private readonly EncryptorInterface $encryptor
+    ) {
+    }
+
+    public function isEnabled(?int $storeId = null): bool
+    {
+        return $this->scopeConfig->isSetFlag(self::XML_PATH_ENABLED, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    public function getApiKey(?int $storeId = null): string
+    {
+        $value = (string) $this->scopeConfig->getValue(self::XML_PATH_API_KEY, ScopeInterface::SCOPE_STORE, $storeId);
+
+        return $value !== '' ? $this->encryptor->decrypt($value) : '';
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAllowedCountries(?int $storeId = null): array
+    {
+        $value = (string) $this->scopeConfig->getValue(self::XML_PATH_COUNTRY_FILTER, ScopeInterface::SCOPE_STORE, $storeId);
+        if ($value === '') {
+            return [];
+        }
+
+        return array_filter(array_map('trim', explode(',', $value)));
+    }
+
+    public function getMinimumScore(?int $storeId = null): float
+    {
+        $value = (string) $this->scopeConfig->getValue(self::XML_PATH_MINIMUM_SCORE, ScopeInterface::SCOPE_STORE, $storeId);
+        return $value === '' ? 0.0 : (float) $value;
+    }
+}

--- a/app/code/Idealpostcodes/AddressValidation/Plugin/Checkout/GuestPaymentInformationManagementPlugin.php
+++ b/app/code/Idealpostcodes/AddressValidation/Plugin/Checkout/GuestPaymentInformationManagementPlugin.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+namespace Idealpostcodes\AddressValidation\Plugin\Checkout;
+
+use Idealpostcodes\AddressValidation\Model\AddressDataExtractor;
+use Idealpostcodes\AddressValidation\Model\Api\AddressValidator;
+use Idealpostcodes\AddressValidation\Model\Api\ValidationResult;
+use Magento\Checkout\Model\GuestPaymentInformationManagement;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Phrase;
+use Magento\Quote\Api\Data\AddressInterface;
+use Magento\Quote\Api\Data\PaymentInterface;
+use function __;
+
+class GuestPaymentInformationManagementPlugin
+{
+    public function __construct(
+        private readonly AddressDataExtractor $dataExtractor,
+        private readonly AddressValidator $addressValidator
+    ) {
+    }
+
+    /**
+     * @throws LocalizedException
+     */
+    public function beforeSavePaymentInformation(
+        GuestPaymentInformationManagement $subject,
+        $cartId,
+        $email,
+        PaymentInterface $paymentMethod,
+        ?AddressInterface $billingAddress = null
+    ): array {
+        if ($billingAddress) {
+            $this->validateAddress($billingAddress, $billingAddress->getStoreId());
+        }
+
+        return [$cartId, $email, $paymentMethod, $billingAddress];
+    }
+
+    /**
+     * @throws LocalizedException
+     */
+    public function beforeSavePaymentInformationAndPlaceOrder(
+        GuestPaymentInformationManagement $subject,
+        $cartId,
+        $email,
+        PaymentInterface $paymentMethod,
+        ?AddressInterface $billingAddress = null
+    ): array {
+        if ($billingAddress) {
+            $this->validateAddress($billingAddress, $billingAddress->getStoreId());
+        }
+
+        return [$cartId, $email, $paymentMethod, $billingAddress];
+    }
+
+    /**
+     * @throws LocalizedException
+     */
+    private function validateAddress(AddressInterface $address, ?int $storeId = null): void
+    {
+        $addressData = $this->dataExtractor->extract($address);
+        $result = $this->addressValidator->validate($addressData, $storeId);
+        if (!$result->isValid()) {
+            throw new LocalizedException($this->resolveMessage($result));
+        }
+    }
+
+    private function resolveMessage(ValidationResult $result): Phrase
+    {
+        $message = $result->getMessage();
+        if ($message instanceof Phrase) {
+            return $message;
+        }
+
+        if (is_string($message) && $message !== '') {
+            return __($message);
+        }
+
+        return __('We could not validate the provided address.');
+    }
+}

--- a/app/code/Idealpostcodes/AddressValidation/Plugin/Checkout/PaymentInformationManagementPlugin.php
+++ b/app/code/Idealpostcodes/AddressValidation/Plugin/Checkout/PaymentInformationManagementPlugin.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace Idealpostcodes\AddressValidation\Plugin\Checkout;
+
+use Idealpostcodes\AddressValidation\Model\AddressDataExtractor;
+use Idealpostcodes\AddressValidation\Model\Api\AddressValidator;
+use Idealpostcodes\AddressValidation\Model\Api\ValidationResult;
+use Magento\Checkout\Model\PaymentInformationManagement;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Phrase;
+use Magento\Quote\Api\Data\AddressInterface;
+use Magento\Quote\Api\Data\PaymentInterface;
+use function __;
+
+class PaymentInformationManagementPlugin
+{
+    public function __construct(
+        private readonly AddressDataExtractor $dataExtractor,
+        private readonly AddressValidator $addressValidator
+    ) {
+    }
+
+    /**
+     * @throws LocalizedException
+     */
+    public function beforeSavePaymentInformation(
+        PaymentInformationManagement $subject,
+        $cartId,
+        PaymentInterface $paymentMethod,
+        ?AddressInterface $billingAddress = null
+    ): array {
+        if ($billingAddress) {
+            $this->validateAddress($billingAddress, $billingAddress->getStoreId());
+        }
+
+        return [$cartId, $paymentMethod, $billingAddress];
+    }
+
+    /**
+     * @throws LocalizedException
+     */
+    public function beforeSavePaymentInformationAndPlaceOrder(
+        PaymentInformationManagement $subject,
+        $cartId,
+        PaymentInterface $paymentMethod,
+        ?AddressInterface $billingAddress = null
+    ): array {
+        if ($billingAddress) {
+            $this->validateAddress($billingAddress, $billingAddress->getStoreId());
+        }
+
+        return [$cartId, $paymentMethod, $billingAddress];
+    }
+
+    /**
+     * @throws LocalizedException
+     */
+    private function validateAddress(AddressInterface $address, ?int $storeId = null): void
+    {
+        $addressData = $this->dataExtractor->extract($address);
+        $result = $this->addressValidator->validate($addressData, $storeId);
+        if (!$result->isValid()) {
+            throw new LocalizedException($this->resolveMessage($result));
+        }
+    }
+
+    private function resolveMessage(ValidationResult $result): Phrase
+    {
+        $message = $result->getMessage();
+        if ($message instanceof Phrase) {
+            return $message;
+        }
+
+        if (is_string($message) && $message !== '') {
+            return __($message);
+        }
+
+        return __('We could not validate the provided address.');
+    }
+}

--- a/app/code/Idealpostcodes/AddressValidation/Plugin/Checkout/ShippingInformationManagementPlugin.php
+++ b/app/code/Idealpostcodes/AddressValidation/Plugin/Checkout/ShippingInformationManagementPlugin.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace Idealpostcodes\AddressValidation\Plugin\Checkout;
+
+use Idealpostcodes\AddressValidation\Model\AddressDataExtractor;
+use Idealpostcodes\AddressValidation\Model\Api\AddressValidator;
+use Idealpostcodes\AddressValidation\Model\Api\ValidationResult;
+use Magento\Checkout\Api\Data\ShippingInformationInterface;
+use Magento\Checkout\Model\ShippingInformationManagement;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Phrase;
+use function __;
+
+class ShippingInformationManagementPlugin
+{
+    public function __construct(
+        private readonly AddressDataExtractor $dataExtractor,
+        private readonly AddressValidator $addressValidator
+    ) {
+    }
+
+    /**
+     * @throws LocalizedException
+     */
+    public function beforeSaveAddressInformation(
+        ShippingInformationManagement $subject,
+        $cartId,
+        ShippingInformationInterface $addressInformation
+    ): array {
+        $shipping = $addressInformation->getShippingAddress();
+        if ($shipping) {
+            $this->validateAddress($shipping, $shipping->getStoreId());
+        }
+
+        $billing = $addressInformation->getBillingAddress();
+        if ($billing) {
+            $storeId = method_exists($billing, 'getStoreId') ? $billing->getStoreId() : ($shipping ? $shipping->getStoreId() : null);
+            $this->validateAddress($billing, $storeId);
+        }
+
+        return [$cartId, $addressInformation];
+    }
+
+    /**
+     * @param \Magento\Framework\Api\ExtensibleDataInterface $address
+     * @throws LocalizedException
+     */
+    private function validateAddress($address, ?int $storeId = null): void
+    {
+        $addressData = $this->dataExtractor->extract($address);
+        $result = $this->addressValidator->validate($addressData, $storeId);
+        if (!$result->isValid()) {
+            throw new LocalizedException($this->resolveMessage($result));
+        }
+    }
+
+    private function resolveMessage(ValidationResult $result): Phrase
+    {
+        $message = $result->getMessage();
+        if ($message instanceof Phrase) {
+            return $message;
+        }
+
+        if (is_string($message) && $message !== '') {
+            return __($message);
+        }
+
+        return __('We could not validate the provided address.');
+    }
+}

--- a/app/code/Idealpostcodes/AddressValidation/Plugin/Customer/AddressRepositoryPlugin.php
+++ b/app/code/Idealpostcodes/AddressValidation/Plugin/Customer/AddressRepositoryPlugin.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Idealpostcodes\AddressValidation\Plugin\Customer;
+
+use Idealpostcodes\AddressValidation\Model\AddressDataExtractor;
+use Idealpostcodes\AddressValidation\Model\Api\AddressValidator;
+use Idealpostcodes\AddressValidation\Model\Api\ValidationResult;
+use Magento\Customer\Api\AddressRepositoryInterface;
+use Magento\Customer\Api\Data\AddressInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Phrase;
+use function __;
+
+class AddressRepositoryPlugin
+{
+    public function __construct(
+        private readonly AddressDataExtractor $dataExtractor,
+        private readonly AddressValidator $addressValidator
+    ) {
+    }
+
+    /**
+     * @param AddressRepositoryInterface $subject
+     * @param AddressInterface $address
+     * @throws LocalizedException
+     */
+    public function beforeSave(AddressRepositoryInterface $subject, AddressInterface $address): array
+    {
+        $addressData = $this->dataExtractor->extract($address);
+        $storeId = method_exists($address, 'getStoreId') ? $address->getStoreId() : null;
+        $result = $this->addressValidator->validate($addressData, $storeId !== null ? (int) $storeId : null);
+        if (!$result->isValid()) {
+            throw new LocalizedException($this->resolveMessage($result));
+        }
+
+        return [$address];
+    }
+
+    private function resolveMessage(ValidationResult $result): Phrase
+    {
+        $message = $result->getMessage();
+        if ($message instanceof Phrase) {
+            return $message;
+        }
+
+        if (is_string($message) && $message !== '') {
+            return __($message);
+        }
+
+        return __('We could not validate the provided address.');
+    }
+}

--- a/app/code/Idealpostcodes/AddressValidation/composer.json
+++ b/app/code/Idealpostcodes/AddressValidation/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "idealpostcodes/module-address-validation",
+    "description": "Address validation via Ideal Postcodes autocomplete API.",
+    "type": "magento2-module",
+    "require": {
+        "php": ">=7.4",
+        "magento/framework": "^103.0"
+    },
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "Idealpostcodes\\AddressValidation\\": ""
+        }
+    }
+}

--- a/app/code/Idealpostcodes/AddressValidation/etc/acl.xml
+++ b/app/code/Idealpostcodes/AddressValidation/etc/acl.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<acl xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <resources>
+        <resource id="Magento_Backend::admin">
+            <resource id="Magento_Backend::stores">
+                <resource id="Magento_Backend::stores_settings">
+                    <resource id="Magento_Config::config">
+                        <resource id="Idealpostcodes_AddressValidation::config" title="Ideal Postcodes Address Validation Configuration" sortOrder="820" />
+                    </resource>
+                </resource>
+            </resource>
+        </resource>
+    </resources>
+</acl>

--- a/app/code/Idealpostcodes/AddressValidation/etc/adminhtml/system.xml
+++ b/app/code/Idealpostcodes/AddressValidation/etc/adminhtml/system.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <section id="idealpostcodes" translate="label" type="text" sortOrder="820" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Ideal Postcodes</label>
+            <tab>services</tab>
+            <resource>Idealpostcodes_AddressValidation::config</resource>
+            <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Address Validation</label>
+                <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable Validation</label>
+                    <source_model>Magento\\Config\\Model\\Config\\Source\\Yesno</source_model>
+                </field>
+                <field id="api_key" translate="label" type="obscure" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>API Key</label>
+                    <backend_model>Magento\\Config\\Model\\Config\\Backend\\Encrypted</backend_model>
+                </field>
+                <field id="country_filter" translate="label" type="multiselect" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Restrict to Countries</label>
+                    <comment>Leave empty to validate all countries. Uses ISO2 country codes.</comment>
+                    <source_model>Magento\\Directory\\Model\\Config\\Source\\Country</source_model>
+                </field>
+                <field id="minimum_score" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Minimum Match Score</label>
+                    <validate>validate-number validate-not-negative</validate>
+                    <comment>Numeric value between 0 and 1 representing the minimum confidence score accepted for a suggestion.</comment>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/app/code/Idealpostcodes/AddressValidation/etc/config.xml
+++ b/app/code/Idealpostcodes/AddressValidation/etc/config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/config.xsd">
+    <default>
+        <idealpostcodes>
+            <general>
+                <enabled>0</enabled>
+                <api_key></api_key>
+                <country_filter>GB</country_filter>
+                <minimum_score>0.6</minimum_score>
+            </general>
+        </idealpostcodes>
+    </default>
+</config>

--- a/app/code/Idealpostcodes/AddressValidation/etc/di.xml
+++ b/app/code/Idealpostcodes/AddressValidation/etc/di.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Customer\Api\AddressRepositoryInterface">
+        <plugin name="idealpostcodes_address_validation_customer_address_save" type="Idealpostcodes\AddressValidation\Plugin\Customer\AddressRepositoryPlugin" sortOrder="10" />
+    </type>
+    <type name="Magento\Checkout\Model\ShippingInformationManagement">
+        <plugin name="idealpostcodes_address_validation_shipping_information" type="Idealpostcodes\AddressValidation\Plugin\Checkout\ShippingInformationManagementPlugin" sortOrder="10" />
+    </type>
+    <type name="Magento\Checkout\Model\PaymentInformationManagement">
+        <plugin name="idealpostcodes_address_validation_payment_information" type="Idealpostcodes\AddressValidation\Plugin\Checkout\PaymentInformationManagementPlugin" sortOrder="10" />
+    </type>
+    <type name="Magento\Checkout\Model\GuestPaymentInformationManagement">
+        <plugin name="idealpostcodes_address_validation_guest_payment_information" type="Idealpostcodes\AddressValidation\Plugin\Checkout\GuestPaymentInformationManagementPlugin" sortOrder="10" />
+    </type>
+</config>

--- a/app/code/Idealpostcodes/AddressValidation/etc/module.xml
+++ b/app/code/Idealpostcodes/AddressValidation/etc/module.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Idealpostcodes_AddressValidation" setup_version="1.0.0" />
+</config>

--- a/app/code/Idealpostcodes/AddressValidation/registration.php
+++ b/app/code/Idealpostcodes/AddressValidation/registration.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::MODULE,
+    'Idealpostcodes_AddressValidation',
+    __DIR__
+);


### PR DESCRIPTION
## Summary
- add a Magento 2 module scaffold for Ideal Postcodes address validation with registration, configuration, and adminhtml settings
- implement validation service and utilities to call the Ideal Postcodes Autocomplete API and evaluate results
- plug validation into customer address saves and checkout flows for shipping and billing addresses, with documentation updates

## Testing
- find app -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68d3f99c34d483278d0065814d4eb040