### PR TITLE
Fix ACL XML root node

### DIFF
--- a/app/code/Idealpostcodes/AddressValidation/etc/acl.xml
+++ b/app/code/Idealpostcodes/AddressValidation/etc/acl.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0"?>
-<acl xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
-    <resources>
-        <resource id="Magento_Backend::admin">
-            <resource id="Magento_Backend::stores">
-                <resource id="Magento_Backend::stores_settings">
-                    <resource id="Magento_Config::config">
-                        <resource id="Idealpostcodes_AddressValidation::config" title="Ideal Postcodes Address Validation Configuration" sortOrder="820" />
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::stores">
+                    <resource id="Magento_Backend::stores_settings">
+                        <resource id="Magento_Config::config">
+                            <resource id="Idealpostcodes_AddressValidation::config" title="Ideal Postcodes Address Validation Configuration" sortOrder="820" />
+                        </resource>
                     </resource>
                 </resource>
             </resource>
-        </resource>
-    </resources>
-</acl>
+        </resources>
+    </acl>
+</config>


### PR DESCRIPTION
## Summary
- wrap the ACL configuration in the expected <config> root element to satisfy Magento's schema

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3fe67f71c8327ab111c444825167a