### PR TITLE
Fix system config tab definition

### DIFF
--- a/app/code/Idealpostcodes/AddressValidation/etc/adminhtml/system.xml
+++ b/app/code/Idealpostcodes/AddressValidation/etc/adminhtml/system.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <section id="idealpostcodes" translate="label" type="text" sortOrder="820" showInDefault="1" showInWebsite="1" showInStore="1">
+        <tab id="idealpostcodes" translate="label" sortOrder="820">
             <label>Ideal Postcodes</label>
-            <tab>services</tab>
+        </tab>
+        <section id="idealpostcodes" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Ideal Postcodes</label>
+            <tab>idealpostcodes</tab>
             <resource>Idealpostcodes_AddressValidation::config</resource>
             <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Address Validation</label>


### PR DESCRIPTION
## Summary
- add a dedicated `idealpostcodes` tab definition to the system configuration XML
- point the section at the new tab to resolve the undefined array key warning

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d3ffa260008327aef5134aec90d796