### PR TITLE
Fix admin config source model class references

### DIFF
--- a/app/code/Idealpostcodes/AddressValidation/etc/adminhtml/system.xml
+++ b/app/code/Idealpostcodes/AddressValidation/etc/adminhtml/system.xml
@@ -12,16 +12,16 @@
                 <label>Address Validation</label>
                 <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Validation</label>
-                    <source_model>Magento\\Config\\Model\\Config\\Source\\Yesno</source_model>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="api_key" translate="label" type="obscure" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>API Key</label>
-                    <backend_model>Magento\\Config\\Model\\Config\\Backend\\Encrypted</backend_model>
+                    <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                 </field>
                 <field id="country_filter" translate="label" type="multiselect" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Restrict to Countries</label>
                     <comment>Leave empty to validate all countries. Uses ISO2 country codes.</comment>
-                    <source_model>Magento\\Directory\\Model\\Config\\Source\\Country</source_model>
+                    <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
                 </field>
                 <field id="minimum_score" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Minimum Match Score</label>


### PR DESCRIPTION
## Summary
- fix the adminhtml system configuration XML to reference Magento source and backend models with correct namespace separators

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d40162d14c83278b2809a86a8e2cae